### PR TITLE
Updated readme, dockerfile, and vscode tasks for QCDE 3.1

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build Linux Image",
             "type": "shell",
-            "command": "docker pull debian:trixie-slim; docker build . -f linux.Dockerfile -t lacledeslan/gamesvr-qcde --no-cache --build-arg BUILDNODE=$env:computername;",
+            "command": "docker pull debian:trixie-slim; docker build . -f linux.Dockerfile -t lltest/gamesvr-qcde --no-cache --build-arg BUILDNODE=$env:computername;",
             "dependsOn": "download-sub-modules",
             "group": "build",
             "problemMatcher": [],
@@ -15,7 +15,7 @@
         {
             "label": "Build & Run Interactive Server",
             "type": "shell",
-            "command": "docker run -it --net=host lltest/gamesvr-qcde;",
+            "command": "docker run -it --net=host lltest/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-test.cfg +exec LAN.cfg;",
             "dependsOn": "Build Linux Image",
             "group": "build",
             "problemMatcher": [],

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ wads](https://freedoom.github.io/download.html) that comes with the installation
 This command is case sensitive on the file names.
 
 ```shell
-docker run -it --rm --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-test.cfg +exec LAN.cfg;
+docker run -it --rm --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-test.cfg +exec LAN.cfg;
 ```
 
 ### Running Game Servers
@@ -68,7 +68,7 @@ Note: Every player class except Sarge will have UT style movement.
 An example of the command line would be as follows.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 qcde_ut_weapons_v3.0.pk3 qcde_ut_movement_v3.0.pk3  -optfile QCDEmus3.0.pk3 +exec qcde-dm.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 qcde_ut_weapons_v3.0.pk3 qcde_ut_movement_v3.0.pk3  -optfile QCDEmus3.0.pk3 +exec qcde-dm.cfg +exec LAN.cfg;
 ```
 
 #### Capture the Flag
@@ -79,7 +79,7 @@ your flag carrier safely scores a point for the team. If the carrier dies while 
 dropped allowing enemies to pick it up and allies to return it back to base.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-ctf.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-ctf.cfg +exec LAN.cfg;
 ```
 
 #### Deathmatch
@@ -88,7 +88,7 @@ The classic game mode: simply shoot as many players as you see. The game ends wh
 time limit is reached.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-dm.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-dm.cfg +exec LAN.cfg;
 ```
 
 #### Domination
@@ -98,7 +98,7 @@ capture. If nobody is controlling the point, then the light is white. To take co
 and it's yours! Every 3 seconds, your team receives 1 point for each point under your control.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-dom.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-dom.cfg +exec LAN.cfg;
 ```
 
 #### Duel
@@ -107,7 +107,7 @@ Duel is effectively one-on-one Deathmatch. Two players fight against each other,
 play the winner. To win in a duel game, you must frag the other player until you reach the frag limit.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-duel.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-duel.cfg +exec LAN.cfg;
 ```
 
 #### InstaGib Deathmatch
@@ -116,7 +116,7 @@ Deathmatch where everyone spawns with a railgun, with no other items spawning. T
 one hit, it will instantly kill you with so much damage that you are gibbed (hence "instagib".)
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-instagib-dm.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-instagib-dm.cfg +exec LAN.cfg;
 ```
 
 #### Invasion
@@ -124,7 +124,7 @@ docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad fr
 A co-operative game mode in which there are multiple increasingly difficult waves of monsters to fight.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-invasion.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-invasion.cfg +exec LAN.cfg;
 ```
 
 #### Last Man Standing
@@ -134,7 +134,7 @@ player alive. You receive all the weapons available, minus the BFG. In LMS, you 
 alive for each round.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-lms.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-lms.cfg +exec LAN.cfg;
 ```
 
 #### Survival Cooperative
@@ -143,7 +143,7 @@ A twist on co-operative in which each player has a set amount of lives. If you r
 the next map. If everyone runs out of lives, you lose and have to start again.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-survival.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-survival.cfg +exec LAN.cfg;
 ```
 
 #### Team Deathmatch
@@ -151,7 +151,7 @@ docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad fr
 Team Deathmatch takes Deathmatch and splits players into teams.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-tdm.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-tdm.cfg +exec LAN.cfg;
 ```
 
 #### Team Last Man Standing
@@ -160,7 +160,7 @@ Team Last Man Standing (TLMS) takes the rules of Last Man Standing and applies i
 team standing wins a point.
 
 ```shell
-docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.0.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-tlms.cfg +exec LAN.cfg;
+docker run -it --net=host lacledeslan/gamesvr-qcde ./q-zandronum-server -iwad freedoom2.wad -file QCDEv3.1_beta_2.pk3 QCDEmaps3.0.pk3 -optfile QCDEmus3.0.pk3 +exec qcde-tlms.cfg +exec LAN.cfg;
 ```
 
 ## Other Consideration

--- a/linux.Dockerfile
+++ b/linux.Dockerfile
@@ -11,12 +11,11 @@ RUN echo "Downloading Q-Zandronum 1.4.22 for Linux (amd64)" &&`
         tar -xzf /tmp/q-zandronum.tar.gz -C /output;
 
 RUN echo "Downloading QC:DE 3.1 Beta 2 Mod Files" &&`
-    curl -sSL "http://${contentServer}/fastDownloads/_installers/QCDEv3.1_beta_2.zip" -o /tmp/qcde.zip &&`
-echo "Validating download against known hash" &&`
-    echo "55f7d9e99b8e2d4e0e193b2f0275501e6d9c1ebd29cadbea6a0da48a8587e3e0  /tmp/qcde.zip" | sha256sum -c - &&`
-echo "Extracting QC:DE" &&`
-    mkdir --parents /output/.config/zandronum &&`
-    unzip /tmp/qcde.zip -d /output/.config/zandronum;
+        curl -sSL "http://${contentServer}/fastDownloads/_installers/qcde/QCDE_v3.1_beta2.tar.gz" -o /tmp/QCDE_v3.1_beta2.tar.gz &&`
+    echo "Validating download against known hash" &&`
+        echo "d805bbec1473f8aab34eae4f4810749085fd508b6b43a2efe03f3e7538824e31  /tmp/QCDE_v3.1_beta2.tar.gz" | sha256sum -c - &&`
+    echo "Extracting Q-C:DE wads" &&`
+        tar -xzf /tmp/QCDE_v3.1_beta2.tar.gz -C /output;
 
 COPY ./dist /output
 
@@ -27,8 +26,7 @@ HEALTHCHECK NONE
 ARG BUILDNODE=unspecified
 ARG SOURCE_COMMIT=unspecified
 
-ENV DOOMWADDIR=/app/wads `
-    LANG=en_US.UTF-8 `
+ENV LANG=en_US.UTF-8 `
     LANGUAGE=en_US.UTF-8 `
     LC_ALL=en_US.UTF-8
 


### PR DESCRIPTION
Updated for QCDE 3.1 Beta 2.  Fixed dockerfile to download wads into app folder.  Fixed vscode task to to create test docker image. Updated readme to use new pk3 and wads.